### PR TITLE
Add obstacles and improved dino visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ assets/           # Placeholder directory for images and sounds
 ```
 
 Open `index.html` in a modern browser to run the current prototype. The game logic is intentionally simple and serves as a starting point for future enhancements described above.
-Click on the canvas to make the dinosaur jump.
+Click on the canvas to make the dinosaur jump and avoid the cacti.
 

--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@ body {
 }
 
 #game-canvas {
-    background-color: #fff;
+    background-color: #eaeaea;
     border: 1px solid #333;
 }
 

--- a/js/game.js
+++ b/js/game.js
@@ -6,6 +6,10 @@ const scoreDisplay = document.getElementById('score');
 let running = false;
 let score = 0;
 let frameId;
+let spawnCounter = 0;
+const obstacles = [];
+const groundHeight = 20;
+const gameSpeed = 6;
 
 const dinosaur = {
     x: 50,
@@ -19,19 +23,64 @@ const dinosaur = {
 };
 
 function resetDinoPosition() {
-    dinosaur.y = canvas.height - dinosaur.height - 20;
+    dinosaur.y = canvas.height - dinosaur.height - groundHeight;
+}
+
+function spawnObstacle() {
+    const height = 30 + Math.random() * 20;
+    obstacles.push({
+        x: canvas.width,
+        y: canvas.height - height - groundHeight,
+        width: 15,
+        height
+    });
+}
+
+function updateObstacles() {
+    for (let i = obstacles.length - 1; i >= 0; i--) {
+        const obs = obstacles[i];
+        obs.x -= gameSpeed;
+        if (obs.x + obs.width < 0) {
+            obstacles.splice(i, 1);
+        }
+    }
+}
+
+function drawObstacles() {
+    ctx.fillStyle = 'green';
+    obstacles.forEach(obs => {
+        ctx.fillRect(obs.x, obs.y, obs.width, obs.height);
+    });
+}
+
+function checkCollisions() {
+    for (const obs of obstacles) {
+        if (
+            dinosaur.x < obs.x + obs.width &&
+            dinosaur.x + dinosaur.width > obs.x &&
+            dinosaur.y < obs.y + obs.height &&
+            dinosaur.y + dinosaur.height > obs.y
+        ) {
+            stopGame();
+            startBtn.textContent = 'Start';
+            break;
+        }
+    }
 }
 
 function clearCanvas() {
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = '#eaeaea';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+    // ground
+    ctx.fillStyle = '#dedede';
+    ctx.fillRect(0, canvas.height - groundHeight, canvas.width, groundHeight);
 }
 
 function updateDino() {
     if (dinosaur.isJumping) {
         dinosaur.y += dinosaur.velocityY;
         dinosaur.velocityY += dinosaur.gravity;
-        const ground = canvas.height - dinosaur.height - 20;
+        const ground = canvas.height - dinosaur.height - groundHeight;
         if (dinosaur.y >= ground) {
             dinosaur.y = ground;
             dinosaur.velocityY = 0;
@@ -42,13 +91,33 @@ function updateDino() {
 
 function drawDino() {
     ctx.fillStyle = '#333';
-    ctx.fillRect(dinosaur.x, dinosaur.y, dinosaur.width, dinosaur.height);
+    // body
+    ctx.fillRect(dinosaur.x, dinosaur.y + 10, 25, 15);
+    // head
+    ctx.fillRect(dinosaur.x + 20, dinosaur.y, 15, 15);
+    // legs
+    ctx.fillRect(dinosaur.x, dinosaur.y + 25, 10, 15);
+    ctx.fillRect(dinosaur.x + 15, dinosaur.y + 25, 10, 15);
+    // tail
+    ctx.beginPath();
+    ctx.moveTo(dinosaur.x, dinosaur.y + 15);
+    ctx.lineTo(dinosaur.x - 10, dinosaur.y + 10);
+    ctx.lineTo(dinosaur.x, dinosaur.y + 20);
+    ctx.fill();
 }
 
 function draw() {
     clearCanvas();
     updateDino();
+    updateObstacles();
     drawDino();
+    drawObstacles();
+    checkCollisions();
+
+    spawnCounter++;
+    if (spawnCounter % 90 === 0) {
+        spawnObstacle();
+    }
 
     score += 1;
     scoreDisplay.textContent = score;


### PR DESCRIPTION
## Summary
- make instructions mention cacti
- tweak canvas background color
- implement dinosaur sprite made of shapes
- add moving cactus obstacles with simple collision detection

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850065fc14c83309895af3e407ceb16